### PR TITLE
TECH: Possible fix for AWS ELB 502 errors

### DIFF
--- a/src/web.js
+++ b/src/web.js
@@ -109,6 +109,8 @@ const httpServer = function httpServer(options: OptionsType) {
 
   // $FlowBug
   const webserver = http.Server(app); // eslint-disable-line
+  webserver.keepAliveTimeout = 65000;
+  webserver.headersTimeout = 66000;
   const io = socketio(webserver);
 
   app.use(helmet());

--- a/src/web.js
+++ b/src/web.js
@@ -109,8 +109,8 @@ const httpServer = function httpServer(options: OptionsType) {
 
   // $FlowBug
   const webserver = http.Server(app); // eslint-disable-line
-  webserver.keepAliveTimeout = 65000;
-  webserver.headersTimeout = 66000;
+  webserver.keepAliveTimeout = options.keepAliveTimeout || 65000;
+  webserver.headersTimeout = options.headersTimeout || 66000;
   const io = socketio(webserver);
 
   app.use(helmet());

--- a/src/web.js
+++ b/src/web.js
@@ -91,6 +91,8 @@ type OptionsType = {
     etag?: boolean,
     lastModified?: boolean,
   },
+  keepAliveTimeout?: number,
+  headersTimeout?: number,
 };
 
 const {


### PR DESCRIPTION
I'm not sure if this is the proper way to be setting these values as we're not doing things the same way as the example in the article.
Our timeout for the support database in AWS is the default 60 seconds.

Reference: https://adamcrowder.net/posts/node-express-api-and-aws-alb-502/

~We can probably make this hard coded for now as a test and if it works we can possibly change it to an optional config token?~ Option params were added